### PR TITLE
Fix CodingLab layout: use responsive flex instead of resizable panels

### DIFF
--- a/app/lab/page.tsx
+++ b/app/lab/page.tsx
@@ -6,7 +6,6 @@ import { Play, Share2, Rocket } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
 import { useToast } from "@/hooks/use-toast";
-import { ResizablePanelGroup, ResizablePanel, ResizableHandle } from "@/components/ui/resizable";
 
 import { EditorPanel } from "@/components/csslab/editor-panel";
 import { PreviewPanel } from "@/components/csslab/preview-panel";
@@ -256,42 +255,31 @@ function LabContent() {
       </div>
 
       {/* Main Layout */}
-      <div className="flex-1 min-h-0 h-full">
-        <ResizablePanelGroup direction="horizontal" className="h-full">
-          {/* Editor Panel */}
-          <ResizablePanel defaultSize={45} minSize={20}>
-            <EditorPanel
-              html={html}
-              css={css}
-              js={js}
-              onHtmlChange={setHtml}
-              onCssChange={setCss}
-              onJsChange={setJs}
-            />
-          </ResizablePanel>
+      <div className="flex flex-col lg:flex-row flex-1 min-h-0 overflow-hidden w-full h-full">
+        {/* Editor Panel */}
+        <div className="w-full lg:w-1/3 h-1/3 lg:h-full flex flex-col overflow-hidden">
+          <EditorPanel
+            html={html}
+            css={css}
+            js={js}
+            onHtmlChange={setHtml}
+            onCssChange={setCss}
+            onJsChange={setJs}
+          />
+        </div>
 
-          <ResizableHandle className="bg-gray-800 hover:bg-blue-500 transition-colors w-1" />
+        {/* Preview Panel */}
+        <div className="w-full lg:w-1/3 h-1/3 lg:h-full flex flex-col overflow-hidden border-y lg:border-y-0 lg:border-x border-gray-800">
+          <PreviewPanel srcDoc={srcDoc} />
+        </div>
 
-          {/* Preview & Terminal Right Side */}
-          <ResizablePanel defaultSize={55} minSize={30}>
-            <ResizablePanelGroup direction="vertical">
-              {/* Preview Panel */}
-              <ResizablePanel defaultSize={70} minSize={20}>
-                <PreviewPanel srcDoc={srcDoc} />
-              </ResizablePanel>
-
-              <ResizableHandle className="bg-gray-800 hover:bg-blue-500 transition-colors h-1" />
-
-              {/* Terminal Panel */}
-              <ResizablePanel defaultSize={30} minSize={10}>
-                <TerminalPanel
-                  logs={logs}
-                  onClear={() => setLogs([])}
-                />
-              </ResizablePanel>
-            </ResizablePanelGroup>
-          </ResizablePanel>
-        </ResizablePanelGroup>
+        {/* Terminal Panel */}
+        <div className="w-full lg:w-1/3 h-1/3 lg:h-full flex flex-col overflow-hidden">
+          <TerminalPanel
+            logs={logs}
+            onClear={() => setLogs([])}
+          />
+        </div>
       </div>
     </div>
   );

--- a/components/csslab/editor-panel.tsx
+++ b/components/csslab/editor-panel.tsx
@@ -18,8 +18,8 @@ export function EditorPanel({
   onJsChange,
 }: EditorPanelProps) {
   return (
-    <div className="h-full flex flex-col bg-gray-950 border-r border-gray-800">
-      <Tabs defaultValue="html" className="flex-1 flex flex-col">
+    <div className="h-full w-full flex flex-col bg-gray-950 overflow-hidden">
+      <Tabs defaultValue="html" className="flex-1 flex flex-col overflow-hidden">
         <div className="bg-gray-900 border-b border-gray-800 px-2">
           <TabsList className="bg-transparent space-x-2 h-10">
             <TabsTrigger
@@ -43,29 +43,29 @@ export function EditorPanel({
           </TabsList>
         </div>
 
-        <TabsContent value="html" className="flex-1 m-0">
+        <TabsContent value="html" className="flex-1 h-full w-full m-0">
           <textarea
             value={html}
             onChange={(e) => onHtmlChange(e.target.value)}
-            className="w-full h-full bg-gray-950 text-gray-300 p-4 font-mono text-sm focus:outline-none resize-none"
+            className="w-full h-full flex-1 bg-gray-950 text-gray-300 p-4 font-mono text-sm focus:outline-none resize-none overflow-auto"
             spellCheck="false"
             placeholder="<!-- Write your HTML here -->"
           />
         </TabsContent>
-        <TabsContent value="css" className="flex-1 m-0">
+        <TabsContent value="css" className="flex-1 h-full w-full m-0">
           <textarea
             value={css}
             onChange={(e) => onCssChange(e.target.value)}
-            className="w-full h-full bg-gray-950 text-gray-300 p-4 font-mono text-sm focus:outline-none resize-none"
+            className="w-full h-full flex-1 bg-gray-950 text-gray-300 p-4 font-mono text-sm focus:outline-none resize-none overflow-auto"
             spellCheck="false"
             placeholder="/* Write your CSS here */"
           />
         </TabsContent>
-        <TabsContent value="js" className="flex-1 m-0">
+        <TabsContent value="js" className="flex-1 h-full w-full m-0">
           <textarea
             value={js}
             onChange={(e) => onJsChange(e.target.value)}
-            className="w-full h-full bg-gray-950 text-gray-300 p-4 font-mono text-sm focus:outline-none resize-none"
+            className="w-full h-full flex-1 bg-gray-950 text-gray-300 p-4 font-mono text-sm focus:outline-none resize-none overflow-auto"
             spellCheck="false"
             placeholder="// Write your JavaScript here"
           />

--- a/components/csslab/preview-panel.tsx
+++ b/components/csslab/preview-panel.tsx
@@ -4,15 +4,15 @@ interface PreviewPanelProps {
 
 export function PreviewPanel({ srcDoc }: PreviewPanelProps) {
   return (
-    <div className="h-full bg-white relative">
-      <div className="bg-gray-900 border-b border-gray-800 px-4 py-1.5 flex justify-between items-center text-xs text-gray-400 absolute top-0 left-0 right-0 z-10">
+    <div className="h-full w-full flex flex-col overflow-hidden bg-white">
+      <div className="bg-gray-900 border-b border-gray-800 px-4 py-1.5 flex justify-between items-center text-xs text-gray-400">
         <span>Preview Output</span>
       </div>
       <iframe
         title="preview"
         srcDoc={srcDoc}
         sandbox="allow-scripts allow-modals"
-        className="w-full h-full border-none pt-8"
+        className="flex-1 w-full h-full border-none"
       />
     </div>
   );

--- a/components/csslab/terminal-panel.tsx
+++ b/components/csslab/terminal-panel.tsx
@@ -5,7 +5,7 @@ interface TerminalPanelProps {
 
 export function TerminalPanel({ logs, onClear }: TerminalPanelProps) {
   return (
-    <div className="h-full bg-gray-900 flex flex-col">
+    <div className="h-full w-full flex flex-col bg-gray-900 overflow-hidden">
       <div className="bg-gray-950 border-b border-t border-gray-800 px-4 py-1.5 flex justify-between items-center text-xs text-gray-400">
         <span>Console</span>
         <button


### PR DESCRIPTION
This PR completely redesigns the coding lab environment to properly display a fixed 3-column view (desktop) and stacked column view (mobile). It relies on flexbox `lg:w-1/3` to enforce this constraint cleanly.

- Removed `ResizablePanel` components to make it structurally fixed layout.
- Added `w-full h-full` and proper flex constraints directly to `PreviewPanel`, `TerminalPanel` and `EditorPanel`.
- Verified UI successfully through `next build` and playwright scripts showing clear structure and responsive stacking.

---
*PR created automatically by Jules for task [12252911800693160530](https://jules.google.com/task/12252911800693160530) started by @RayBen445*